### PR TITLE
Introduce pessimism in VPG using a state-only VAE

### DIFF
--- a/src/garage/shortrl/algorithms.py
+++ b/src/garage/shortrl/algorithms.py
@@ -27,8 +27,7 @@ def get_algo(*,
              policy_network_hidden_nonlinearity=torch.tanh,
              value_natwork_hidden_sizes=(256, 128),
              value_network_hidden_nonlinearity=torch.tanh,
-             value_ensemble_size=1, # ensemble size of value network
-             value_ensemble_mode='P', # ensemble mode of value network, P or O
+
              policy_lr=1e-3,  # optimization stepsize for policy update
              value_lr=1e-3,  # optimization stepsize for value regression
              opt_minibatch_size=128,  # optimization/replaybuffer minibatch size
@@ -56,6 +55,12 @@ def get_algo(*,
     assert isinstance(env, GymEnv) or env is None
     assert not (env is None and episode_batch is None)
     assert batch_size is not None
+
+    # Parse algo_name
+    if '_' in algo_name:
+        algo_name, ensemble_mode = algo_name.split('_')
+        value_ensemble_size= int(ensemble_mode[:-1]) # ensemble size of value network
+        value_ensemble_mode= ensemble_mode[-1] # ensemble mode of value network, P or O
 
     # For normalized behaviors
     opt_n_grad_steps = int(opt_n_grad_steps/steps_per_epoch)
@@ -149,6 +154,7 @@ def get_algo(*,
 
         # Use vae to induce pessimism.
         vae = vae_optimizer = None
+        use_pessimism = False
         if algo_name=='VAEVPG':
             from garage.shortrl.vaes import StateVAE
             use_pessimism = True

--- a/src/garage/shortrl/heuristics.py
+++ b/src/garage/shortrl/heuristics.py
@@ -35,12 +35,12 @@ class _Pessimistic_Vf:
 
 def get_algo_vf(algo, pessimism_threshold):
     # load heuristic
-    if type(algo).__name__ in ['PPO','TRPO']:
+    if type(algo).__name__ in ['PPO','TRPO', 'VPG']:
         vf = algo._value_function
     elif type(algo).__name__ in ['SAC', 'TD3', 'CQL']:
         qfs = [algo._qf1, algo._qf2]
         vf = _Vf(algo.policy, qfs)
-    elif type(algo).__name__ in ['VPG']:
+    elif type(algo).__name__ in ['VAEVPG']:
         vf = _Pessimistic_Vf(algo._value_function, algo._is_pessimistic, algo.vae,
                 algo._vmin, pessimism_threshold)
     else:
@@ -66,5 +66,5 @@ def load_heuristic_from_snapshot(path, itr='last', pessimism_threshold=0):
     snapshotter = Snapshotter()
     data = snapshotter.load(path, itr=itr)
     algo = data['algo']
-    vf = get_algo_vf(algo)
+    vf = get_algo_vf(algo, pessimism_threshold)
     return torch_method(vf)

--- a/src/garage/shortrl/heuristics.py
+++ b/src/garage/shortrl/heuristics.py
@@ -40,7 +40,10 @@ def get_algo_vf(algo, vae_loss_percentile=None):
         qfs = [algo._qf1, algo._qf2]
         vf = _Vf(algo.policy, qfs)
     elif type(algo).__name__ in ['VPG']:  # TODO this can be ambiguous
-        pessimism_threshold = algo.vae_loss_percentile[vae_loss_percentile] if algo.vae_loss_percentile is not None else None
+        pessimism_threshold = None
+        if vae_loss_percentile is not None and algo.vae_loss_percentile is not None:
+            pessimism_threshold = algo.vae_loss_percentile[vae_loss_percentile]
+
         vf = _Pessimistic_Vf(algo._value_function, algo._is_pessimistic, algo.vae,
                 algo._vmin, pessimism_threshold)
     else:

--- a/src/garage/shortrl/heuristics.py
+++ b/src/garage/shortrl/heuristics.py
@@ -41,7 +41,7 @@ def get_algo_vf(algo, pessimism_threshold):
         qfs = [algo._qf1, algo._qf2]
         vf = _Vf(algo.policy, qfs)
     elif type(algo).__name__ in ['VPG']:
-        vf = _Pessimistic_Vf(algo._value_function, algo._pessimistic_vae_filter, algo._vae, 
+        vf = _Pessimistic_Vf(algo._value_function, algo._is_pessimistic, algo.vae, 
                 algo._vmin, pessimism_threshold)
     else:
         raise ValueError('Unsupported algorithm.')

--- a/src/garage/shortrl/heuristics.py
+++ b/src/garage/shortrl/heuristics.py
@@ -15,13 +15,34 @@ class _Vf:
         pred_qs = [qf(obs, acs) for qf in self.qfs]
         return torch.minimum(*pred_qs)
 
-def get_algo_vf(algo):
+class _Pessimistic_Vf:
+    def __init__(self, vf, is_pessimistic, vae, vmin, beta):
+        self._vf = vf
+        self._vae = vae
+        self._is_pessimistic = is_pessimistic
+        self._vmin = vmin
+        self._beta = beta
+        
+    def __call__(self, obs):
+        if not self._is_pessimistic or self._beta is None or self._beta == 0:
+            return self._vf(obs)
+        else:    
+            score = -self._vae.compute_loss(obs)
+            indicator = torch.sigmoid(100*(score - self._beta))
+        
+            values = indicator * self._vf(obs) + (1 - indicator) * self._vmin
+            return values
+        
+def get_algo_vf(algo, pessimism_threshold):
     # load heuristic
-    if type(algo).__name__ in ['PPO','TRPO','VPG']:
+    if type(algo).__name__ in ['PPO','TRPO']:
         vf = algo._value_function
     elif type(algo).__name__ in ['SAC', 'TD3', 'CQL']:
         qfs = [algo._qf1, algo._qf2]
         vf = _Vf(algo.policy, qfs)
+    elif type(algo).__name__ in ['VPG']:
+        vf = _Pessimistic_Vf(algo._value_function, algo._pessimistic_vae_filter, algo._vae, 
+                algo._vmin, pessimism_threshold)
     else:
         raise ValueError('Unsupported algorithm.')
     return vf
@@ -41,9 +62,9 @@ def load_policy_from_snapshot(path, itr='last'):
     policy = get_algo_policy(algo)
     return policy
 
-def load_heuristic_from_snapshot(path, itr='last'):
+def load_heuristic_from_snapshot(path, itr='last', pessimism_threshold=0):
     snapshotter = Snapshotter()
     data = snapshotter.load(path, itr=itr)
     algo = data['algo']
-    vf = get_algo_vf(algo)
+    vf = get_algo_vf(algo, pessimism_threshold)
     return torch_stop_grad(vf)

--- a/src/garage/shortrl/main.py
+++ b/src/garage/shortrl/main.py
@@ -208,12 +208,12 @@ def train_heuristics(
                      use_raw_snapshot=False,
                      snapshot_frequency=0,
                      save_mode='light',
-                     pessimism_threshold=0,
+                     vae_loss_percentile=0,
                      **kwargs
                      ):
 
     if use_raw_snapshot:
-        heuristic = load_heuristic_from_snapshot(data_path, data_itr, pessimism_threshold)
+        heuristic = load_heuristic_from_snapshot(data_path, data_itr, vae_loss_percentile)
         return heuristic
 
     train_from_mixed_data = isinstance(data_itr, list) or isinstance(data_itr, tuple)
@@ -255,7 +255,7 @@ def train_heuristics(
 
 
     print("Load heuristic snapshot.")
-    heuristic = load_heuristic_from_snapshot(log_dir, 'last', pessimism_threshold)
+    heuristic = load_heuristic_from_snapshot(log_dir, 'last', vae_loss_percentile)
     assert heuristic is not None
     return heuristic
 
@@ -546,7 +546,7 @@ if __name__ == '__main__':
     parser.add_argument('--use_raw_snapshot', type=str2bool, default=False)
     parser.add_argument('--h_algo_name', type=str, default='VPG')
     parser.add_argument('--h_n_epoch', type=int, default=30)
-    parser.add_argument('--pessimism_threshold', type=float, default=0.0)
+    parser.add_argument('--vae_loss_percentile', type=int, default=0)
     parser.add_argument('--ls_rate', type=float, default=1)
     parser.add_argument('--ls_cls', type=str, default='TanhLS')
     # logging

--- a/src/garage/shortrl/main.py
+++ b/src/garage/shortrl/main.py
@@ -415,8 +415,6 @@ def run_exp(*,
             data_path=None,  # directory of the snapshot
             data_itr=None,
             episode_batch_size=50000,
-            offline_value_ensemble_size=1,
-            offline_value_ensemble_mode='P',
             # pretrain policy
             warmstart_policy=False,
             w_algo_name='BC',
@@ -460,8 +458,6 @@ def run_exp(*,
                                 batch_size=batch_size,
                                 seed=seed,
                                 use_raw_snapshot=use_raw_snapshot,
-                                value_ensemble_size=offline_value_ensemble_size,
-                                value_ensemble_mode=offline_value_ensemble_mode,
                                 **kwargs
                                 )
             if warmstart_policy:
@@ -489,7 +485,7 @@ def run_exp(*,
 
     # Define log_dir based on garage's logging convention
     exp_name = algo_name+'_'+ env_name[:min(len(env_name),5)]+\
-                '_{}_{}_{}'.format(lambd, str(use_heuristic)[0], str(warmstart_policy)[0])
+                '_{}_{}_{}'.format(lambd, str(h_algo_name), str(warmstart_policy)[0])
     prefix= os.path.join('shortrl',log_prefix,exp_name)
     name=str(seed)
     log_root = log_root or '.'
@@ -535,7 +531,6 @@ if __name__ == '__main__':
     # parser.add_argument('--data_path', type=str, default='snapshots/SAC_HalfC_1.0_F_F/210566759/')
     # parser.add_argument('--data_itr', type=int, default=(0,9))
     parser.add_argument('--episode_batch_size', type=int, default=10000) #50000)
-    parser.add_argument('--offline_value_ensemble_size', type=int, default=1)
     # pretrain policy
     parser.add_argument('-w', '--warmstart_policy', type=str2bool, default=False)
     parser.add_argument('--w_algo_name', type=str, default='BC')

--- a/src/garage/shortrl/main.py
+++ b/src/garage/shortrl/main.py
@@ -546,7 +546,6 @@ if __name__ == '__main__':
     parser.add_argument('--use_raw_snapshot', type=str2bool, default=False)
     parser.add_argument('--h_algo_name', type=str, default='VPG')
     parser.add_argument('--h_n_epoch', type=int, default=30)
-    parser.add_argument('--use_pessimism', type=str2bool, default=False)
     parser.add_argument('--pessimism_threshold', type=float, default=0.0)
     parser.add_argument('--ls_rate', type=float, default=1)
     parser.add_argument('--ls_cls', type=str, default='TanhLS')
@@ -566,8 +565,5 @@ if __name__ == '__main__':
 
     # Run experiment.
     args_dict = vars(args)
-
-    if args.use_pessimism:
-        args.log_prefix = args.log_prefix + '_Pessimistic'
 
     run_exp(**args_dict)

--- a/src/garage/shortrl/main.py
+++ b/src/garage/shortrl/main.py
@@ -195,11 +195,13 @@ def train_heuristics(
                      use_raw_snapshot=False,
                      snapshot_frequency=0,
                      save_mode='light',
+                     use_pessimism=False,
+                     pessimism_threshold=0,
                      **kwargs
                      ):
 
     if use_raw_snapshot:
-        heuristic = load_heuristic_from_snapshot(data_path, data_itr)
+        heuristic = load_heuristic_from_snapshot(data_path, data_itr, pessimism_threshold)
         return heuristic
 
     train_from_mixed_data = isinstance(data_itr, list) or isinstance(data_itr, tuple)
@@ -243,7 +245,7 @@ def train_heuristics(
 
 
     print("Load heuristic snapshot.")
-    heuristic = load_heuristic_from_snapshot(log_dir, 'last')
+    heuristic = load_heuristic_from_snapshot(log_dir, 'last', pessimism_threshold)
     assert heuristic is not None
     return heuristic
 
@@ -379,6 +381,8 @@ def run_exp(*,
             use_heuristic=False,
             h_algo_name='VPG',
             h_n_epoch=30,
+            use_pessimism=False,
+            pessimism_threshold=0,
             # logging
             snapshot_frequency=0,  # 0 means only taking the last snapshot
             log_root=None,
@@ -412,6 +416,8 @@ def run_exp(*,
                                 batch_size=batch_size,
                                 seed=seed,
                                 use_raw_snapshot=use_raw_snapshot,
+                                use_pessimism=use_pessimism,
+                                pessimism_threshold=pessimism_threshold,
                                 value_ensemble_size=offline_value_ensemble_size,
                                 value_ensemble_mode=offline_value_ensemble_mode,
                                 **kwargs
@@ -521,7 +527,9 @@ if __name__ == '__main__':
     parser.add_argument('--use_raw_snapshot', type=str2bool, default=False)
     parser.add_argument('--h_algo_name', type=str, default='VPG')
     parser.add_argument('--h_n_epoch', type=int, default=30)
-    parser.add_argument('--ls_rate', type=float(), default=1)
+    parser.add_argument('--use_pessimism', type=str2bool, default=False)
+    parser.add_argument('--pessimism_threshold', type=float, default=0.0)
+    parser.add_argument('--ls_rate', type=float, default=1)
     parser.add_argument('--ls_cls', type=str, default='TanhLS')
     # logging
     parser.add_argument('--snapshot_frequency', type=int, default=0)

--- a/src/garage/shortrl/main.py
+++ b/src/garage/shortrl/main.py
@@ -195,7 +195,6 @@ def train_heuristics(
                      use_raw_snapshot=False,
                      snapshot_frequency=0,
                      save_mode='light',
-                     use_pessimism=False,
                      pessimism_threshold=0,
                      **kwargs
                      ):
@@ -381,8 +380,6 @@ def run_exp(*,
             use_heuristic=False,
             h_algo_name='VPG',
             h_n_epoch=30,
-            use_pessimism=False,
-            pessimism_threshold=0,
             # logging
             snapshot_frequency=0,  # 0 means only taking the last snapshot
             log_root=None,
@@ -416,8 +413,6 @@ def run_exp(*,
                                 batch_size=batch_size,
                                 seed=seed,
                                 use_raw_snapshot=use_raw_snapshot,
-                                use_pessimism=use_pessimism,
-                                pessimism_threshold=pessimism_threshold,
                                 value_ensemble_size=offline_value_ensemble_size,
                                 value_ensemble_mode=offline_value_ensemble_mode,
                                 **kwargs
@@ -513,8 +508,8 @@ if __name__ == '__main__':
     parser.add_argument('-b', '--batch_size', type=int, default=10000)
     parser.add_argument('-s', '--seed', type=int, default=1)
     # offline batch data
-    parser.add_argument('--data_path', type=str, default='snapshots/SAC_HalfC_1.0_F_F/210566759/')
-    parser.add_argument('--data_itr', type=int, default=(0,20))
+    parser.add_argument('--data_path', type=str, default='snapshots/VPG_HalfC_1.0_F_F/1/')
+    parser.add_argument('--data_itr', type=int, default=0)
     parser.add_argument('--episode_batch_size', type=int, default=10000) #50000)
     parser.add_argument('--offline_value_ensemble_size', type=int, default=1)
     # pretrain policy
@@ -547,4 +542,8 @@ if __name__ == '__main__':
 
     # Run experiment.
     args_dict = vars(args)
+    
+    if args.use_pessimism:
+        args.log_prefix = args.log_prefix + '_Pessimistic'
+        
     run_exp(**args_dict)

--- a/src/garage/shortrl/main.py
+++ b/src/garage/shortrl/main.py
@@ -530,15 +530,10 @@ if __name__ == '__main__':
     parser.add_argument('-b', '--batch_size', type=int, default=10000)
     parser.add_argument('-s', '--seed', type=int, default=1)
     # offline batch data
-<<<<<<< HEAD
     parser.add_argument('--data_path', type=str, default='snapshots/VPG_HalfC_1.0_F_F/1/')
     parser.add_argument('--data_itr', type=int, default=0)
     # parser.add_argument('--data_path', type=str, default='snapshots/SAC_HalfC_1.0_F_F/210566759/')
     # parser.add_argument('--data_itr', type=int, default=(0,9))
-=======
-    parser.add_argument('--data_path', type=str, default='snapshots/SAC_Inver_1.0_F_F/120032374/')
-    parser.add_argument('--data_itr', type=int, default=8)
->>>>>>> shortrl
     parser.add_argument('--episode_batch_size', type=int, default=10000) #50000)
     parser.add_argument('--offline_value_ensemble_size', type=int, default=1)
     # pretrain policy
@@ -551,11 +546,8 @@ if __name__ == '__main__':
     parser.add_argument('--use_raw_snapshot', type=str2bool, default=False)
     parser.add_argument('--h_algo_name', type=str, default='VPG')
     parser.add_argument('--h_n_epoch', type=int, default=30)
-<<<<<<< HEAD
     parser.add_argument('--use_pessimism', type=str2bool, default=False)
     parser.add_argument('--pessimism_threshold', type=float, default=0.0)
-=======
->>>>>>> shortrl
     parser.add_argument('--ls_rate', type=float, default=1)
     parser.add_argument('--ls_cls', type=str, default='TanhLS')
     # logging

--- a/src/garage/shortrl/trainer.py
+++ b/src/garage/shortrl/trainer.py
@@ -18,7 +18,7 @@ from garage.shortrl.utils import read_attr_from_csv
 
 def get_algodata_cls(algo):
     class Cls:
-        def __init__(self, policy, vf, qf1, qf2, pessimistic, vae, vmin):
+        def __init__(self, *, policy, vf, qf1, qf2, pessimistic, vae, vmin, vae_loss_percentile):
             self.policy = policy
             self._value_function = vf
             self._qf1 = qf1
@@ -26,7 +26,8 @@ def get_algodata_cls(algo):
             self._is_pessimistic = pessimistic
             self.vae = vae
             self._vmin = vmin
-            
+            self.vae_loss_percentile = vae_loss_percentile
+
     Cls.__name__ = type(algo).__name__
     return Cls
 
@@ -80,7 +81,8 @@ class Trainer(garageTrainer):
                                 qf2=getattr(self._algo, '_qf2', None),
                                 pessimistic=getattr(self._algo, '_pessimistic_vae_filter', False),
                                 vae=getattr(self._algo, '_vae', None),
-                                vmin=getattr(self._algo, '_vmin', None))
+                                vmin=getattr(self._algo, '_vmin', None),
+                                vae_loss_percentile=getattr(self._algo, 'vae_loss_percentile', None))
             params['algo'] = algodata
 
         else:  # default behavior: save everything

--- a/src/garage/shortrl/trainer.py
+++ b/src/garage/shortrl/trainer.py
@@ -18,11 +18,15 @@ from garage.shortrl.utils import read_attr_from_csv
 
 def get_algodata_cls(algo):
     class Cls:
-        def __init__(self, policy, vf, qf1, qf2):
+        def __init__(self, policy, vf, qf1, qf2, pessimistic, vae, vmin):
             self.policy = policy
             self._value_function = vf
             self._qf1 = qf1
             self._qf2 = qf2
+            self._is_pessimistic = pessimistic
+            self.vae = vae
+            self._vmin = vmin
+            
     Cls.__name__ = type(algo).__name__
     return Cls
 
@@ -73,7 +77,10 @@ class Trainer(garageTrainer):
             algodata = AlgoData(policy=self._algo.policy,
                                 vf=getattr(self._algo, '_value_function', None),
                                 qf1=getattr(self._algo, '_qf1', None),
-                                qf2=getattr(self._algo, '_qf2', None))
+                                qf2=getattr(self._algo, '_qf2', None),
+                                pessimistic=getattr(self._algo, '_pessimistic_vae_filter', False),
+                                vae=getattr(self._algo, '_vae', None),
+                                vmin=getattr(self._algo, '_vmin', None))
             params['algo'] = algodata
 
         else:  # default behavior: save everything

--- a/src/garage/shortrl/utils.py
+++ b/src/garage/shortrl/utils.py
@@ -14,7 +14,7 @@ def str2bool(v):
 def torch_stop_grad(torch_value):
     def wrapped_fun(x):
         with torch.no_grad():
-            return torch_value(torch.Tensor(x))
+            return torch_value(torch.Tensor(x)).numpy()
     return wrapped_fun
 
 

--- a/src/garage/shortrl/vaes.py
+++ b/src/garage/shortrl/vaes.py
@@ -31,7 +31,7 @@ class StateVAE(GaussianMLPValueFunction):
                         max_std=1e15,
                         std_parameterization='exp',
                         layer_normalization=layer_normalization)
-                        
+
         self._decoder = MLPModule(
                         input_dim=latent_dim,
                         output_dim=input_dim,
@@ -52,5 +52,12 @@ class StateVAE(GaussianMLPValueFunction):
         pred, mean, std = self.forward(obs)
         reconstruction_loss = F.mse_loss(pred, obs)
         KL_loss = -0.5 * (1 + torch.log(std.pow(2)) - mean.pow(2) - std.pow(2)).mean()
+        loss = reconstruction_loss + 0.5 * KL_loss
+        return loss
+
+    def compute_batch_loss(self, obs):
+        pred, mean, std = self.forward(obs)
+        reconstruction_loss = torch.mean(F.mse_loss(pred, obs, reduction='none'), dim=1)
+        KL_loss = -0.5 * (1 + torch.log(std.pow(2)) - mean.pow(2) - std.pow(2)).mean(dim=1)
         loss = reconstruction_loss + 0.5 * KL_loss
         return loss

--- a/src/garage/shortrl/vaes.py
+++ b/src/garage/shortrl/vaes.py
@@ -1,0 +1,58 @@
+import torch
+from torch import nn
+import torch.nn.functional as F
+from garage.torch.modules import GaussianMLPModule
+from garage.torch.value_functions.gaussian_mlp_value_function import GaussianMLPValueFunction
+
+class StateVAE(GaussianMLPValueFunction):
+    def __init__(self,
+                 env_spec,
+                 hidden_sizes=(64, 64),
+                 hidden_nonlinearity=torch.ReLU,
+                 hidden_w_init=nn.init.xavier_uniform_,
+                 hidden_b_init=nn.init.zeros_,
+                 latent_dim=32,
+                 layer_normalization=False,
+                 name='GaussianVAE'):
+        super(GaussianMLPValueFunction, self).__init__(env_spec, name)
+
+        input_dim = env_spec.observation_space.flat_dim
+        self._encoder = GaussianMLPTwoHeadedModule(
+                        input_dim=input_dim,
+                        output_dim=latent_dim,
+                        hidden_sizes=hidden_sizes,
+                        hidden_nonlinearity=hidden_nonlinearity,
+                        hidden_w_init=hidden_w_init,
+                        hidden_b_init=hidden_b_init,
+                        output_nonlinearity=None,
+                        learn_std=True,
+                        init_std=1.0,
+                        min_std=1e-4,
+                        max_std=1e15,
+                        std_parameterization='exp',
+                        layer_normalization=layer_normalization)
+                        
+        self._decoder = GaussianMLPModule(
+                        input_dim=latent_dim,
+                        output_dim=input_dim,
+                        hidden_sizes=hidden_sizes[::-1],
+                        hidden_nonlinearity=hidden_nonlinearity,
+                        hidden_w_init=hidden_w_init,
+                        hidden_b_init=hidden_b_init,
+                        output_nonlinearity=None,
+                        learn_std=False,
+                        layer_normalization=layer_normalization)
+
+    def forward(self, obs):
+        dist = self._encoder(obs)
+        z = dist.rsample(obs.shape[0])
+        print(obs, z)
+        u = self._decoder(z)
+        return u, dist.mean, dist.stddev
+
+    def compute_loss(self, obs):
+        pred, mean, std = self.forward(obs)
+        reconstruction_loss = F.mse_loss(pred, obs)
+        KL_loss = -0.5 * (1 + torch.log(std.pow(2)) - mean.pow(2) - std.pow(2)).mean()
+        loss = recon_loss + 0.5 * KL_loss
+        return loss

--- a/src/garage/torch/algos/vpg.py
+++ b/src/garage/torch/algos/vpg.py
@@ -53,7 +53,7 @@ class VPG(RLAlgorithm):
 
         FIX
         append_terminal_val (bool): Whether to append the value evaluated at the last observation
-        
+
         PESSIMISM
         pessmistic_vae_filter (bool): Whether to filter state value estimates using a VAE.
         value_function (garage.shortrl.StateVAE): The VAE.
@@ -85,7 +85,7 @@ class VPG(RLAlgorithm):
     ):
         # HACK
         self._append_terminal_val = append_terminal_val
-        
+
         self._pessimistic_vae_filter = pessimistic_vae_filter
 
         self._discount = discount
@@ -129,7 +129,7 @@ class VPG(RLAlgorithm):
             else:
                 self._vae_optimizer = OptimizerWrapper(torch.optim.Adam,
                                                   vae)
-                                                  
+
         self._old_policy = copy.deepcopy(self.policy)
 
     @staticmethod
@@ -207,7 +207,6 @@ class VPG(RLAlgorithm):
                 # mask[np.arange(len(ind)), ind] =1
                 mask = np.random.randint(2, size=(len(returns_flat), self._value_function.ensemble_size))
                 eps.env_infos['Mask'] = mask
-                import pdb; pdb.set_trace()
             returns_flat = torch.unsqueeze(returns_flat,-1)
             returns_flat = torch.cat((returns_flat, torch.Tensor(eps.env_infos['Mask'])) , dim=-1)
 
@@ -381,7 +380,7 @@ class VPG(RLAlgorithm):
         self._vae_optimizer.step()
 
         return loss
-        
+
     def _compute_loss(self, obs, actions, rewards, valids, baselines):
         r"""Compute mean value of loss.
 

--- a/src/garage/torch/algos/vpg.py
+++ b/src/garage/torch/algos/vpg.py
@@ -124,6 +124,7 @@ class VPG(RLAlgorithm):
         if self._pessimistic_vae_filter:
             self._vae = vae
             self._vmin = None
+            self.vae_loss_percentile = None
             if vae_optimizer:
                 self._vae_optimizer = vae_optimizer
             else:
@@ -234,6 +235,8 @@ class VPG(RLAlgorithm):
             policy_entropy = self._compute_policy_entropy(obs)
             if self._pessimistic_vae_filter:
                 vae_loss_after = self._vae.compute_loss(obs_flat)
+                batch_loss_after = self._vae.compute_batch_loss(obs_flat)
+                self.vae_loss_percentile = np.percentile(batch_loss_after.numpy(), np.arange(100))
 
         with tabular.prefix(self.policy.name):
             tabular.record('/LossBefore', policy_loss_before.item())

--- a/train_heuristic.py
+++ b/train_heuristic.py
@@ -25,7 +25,7 @@ if env_name=='InvertedDoublePendulum-v2':
 
 if env_name=='HalfCheetah-v2':
     data_path= 'snapshots/SAC_HalfC_1.0_F_F/210566759/'
-    data_itr = 20 # [0,20]
+    data_itr = [0,20]
     policy_network_hidden_sizes=(64, 64)
     value_natwork_hidden_sizes=(256, 256)
     h_n_epoch = 30

--- a/train_heuristic.py
+++ b/train_heuristic.py
@@ -7,10 +7,10 @@ from src.garage.shortrl.main import run_exp
 algo_name='SAC'
 discount = None
 n_epochs = 50
-env_name = 'Ant-v2'
+env_name = 'HalfCheetah-v2'
 batch_size = 10000
 offline_value_ensemble_size = 1
-h_algo_name='VPG'
+h_algo_name='VAEVPG'
 h_n_epoch = 50
 
 
@@ -25,7 +25,7 @@ if env_name=='InvertedDoublePendulum-v2':
 
 if env_name=='HalfCheetah-v2':
     data_path= 'snapshots/SAC_HalfC_1.0_F_F/210566759/'
-    data_itr = [0,20]
+    data_itr = 20 # [0,20]
     policy_network_hidden_sizes=(64, 64)
     value_natwork_hidden_sizes=(256, 256)
     h_n_epoch = 30
@@ -49,7 +49,7 @@ if env_name=='Ant-v2':
 
 
 
-w_n_epoch = data_itr[1]-data_itr[0] if len(data_itr)>1 else 30
+w_n_epoch = data_itr[1]-data_itr[0] if len([data_itr])>1 else 30
 episode_batch_size = batch_size
 
 run_exp(algo_name=algo_name,

--- a/train_heuristic.py
+++ b/train_heuristic.py
@@ -12,7 +12,7 @@ batch_size = 10000
 offline_value_ensemble_size = 1
 h_algo_name='VAEVPG'
 h_n_epoch = 50
-
+vae_loss_percentile = 1  # an interger from 0-99
 
 
 if env_name=='InvertedDoublePendulum-v2':
@@ -76,4 +76,6 @@ run_exp(algo_name=algo_name,
         use_heuristic=True,
         h_algo_name=h_algo_name,
         h_n_epoch=h_n_epoch,
+        # vae parameters
+        vae_loss_percentile=vae_loss_percentile,
         )


### PR DESCRIPTION
Usage:
Run main.py [other options for online training] --use_pessimism True -a VPG to produce snapshots that store the VAE as well as v_min (the value to clip OOD states to). Make note of the GaussianVAELoss printed out during the run, this will be useful to calibrate the threshold for conservatism later.
Then run main.py [other options for shortrl training] --use_pessimism True --use_heuristic --pessimism_threshold [xyz], where xyz is roughly on the order of the error observed in the VPG run.